### PR TITLE
Compatibilty with python < 2.7

### DIFF
--- a/gallery.py
+++ b/gallery.py
@@ -71,8 +71,8 @@ def ProcessDir(indir, is_parent=True, subdirs=[]):
 		all_base_files[name].add(ext)
 	
 	# only keep the entries that have a png
-	base_files = {k: v for k, v in all_base_files.items() if '.png' in v}
-	other_files = {k: v for k, v in all_base_files.items() if '.png' not in v and k.startswith('.') is False}
+	base_files = dict((k, v) for k, v in all_base_files.items() if '.png' in v)
+	other_files = dict((k, v) for k, v in all_base_files.items() if '.png' not in v and k.startswith('.') is False)
 	
 	elements = ''
 	search_box = ''


### PR DESCRIPTION
This commit replaces the dict-comprehension by calls to the dict constructor. This is needed as dict-comprehensions are not available for python < 2.7 (namely python 2.6.6 which is default on lxplus).
